### PR TITLE
Jackpocket FIST pagination changes

### DIFF
--- a/lib/flop_phoenix/pagination.ex
+++ b/lib/flop_phoenix/pagination.ex
@@ -241,49 +241,47 @@ defmodule Flop.Phoenix.Pagination do
     assigns = assign(assigns, first: first, last: last)
 
     ~H"""
-    <ul {@opts[:pagination_list_attrs]}>
-      <.page_link_tag
-        :if={@first > 1}
-        event={@event}
-        meta={@meta}
-        opts={@opts}
-        page={1}
-        page_link_helper={@page_link_helper}
-        target={@target}
-      />
+    <.page_link_tag
+      :if={@first > 1}
+      event={@event}
+      meta={@meta}
+      opts={@opts}
+      page={1}
+      page_link_helper={@page_link_helper}
+      target={@target}
+    />
 
-      <.pagination_ellipsis
-        :if={@first > 2}
-        attrs={@opts[:ellipsis_attrs]}
-        content={@opts[:ellipsis_content]}
-      />
+    <.pagination_ellipsis
+      :if={@first > 2}
+      attrs={@opts[:ellipsis_attrs]}
+      content={@opts[:ellipsis_content]}
+    />
 
-      <.page_link_tag
-        :for={page <- @range}
-        event={@event}
-        meta={@meta}
-        opts={@opts}
-        page={page}
-        page_link_helper={@page_link_helper}
-        target={@target}
-      />
+    <.page_link_tag
+      :for={page <- @range}
+      event={@event}
+      meta={@meta}
+      opts={@opts}
+      page={page}
+      page_link_helper={@page_link_helper}
+      target={@target}
+    />
 
-      <.pagination_ellipsis
-        :if={@last < @meta.total_pages - 1}
-        attrs={@opts[:ellipsis_attrs]}
-        content={@opts[:ellipsis_content]}
-      />
+    <.pagination_ellipsis
+      :if={@last < @meta.total_pages - 1}
+      attrs={@opts[:ellipsis_attrs]}
+      content={@opts[:ellipsis_content]}
+    />
 
-      <.page_link_tag
-        :if={@last < @meta.total_pages}
-        event={@event}
-        meta={@meta}
-        opts={@opts}
-        page={@meta.total_pages}
-        page_link_helper={@page_link_helper}
-        target={@target}
-      />
-    </ul>
+    <.page_link_tag
+      :if={@last < @meta.total_pages}
+      event={@event}
+      meta={@meta}
+      opts={@opts}
+      page={@meta.total_pages}
+      page_link_helper={@page_link_helper}
+      target={@target}
+    />
     """
   end
 
@@ -299,15 +297,11 @@ defmodule Flop.Phoenix.Pagination do
 
     ~H"""
     <%= if @event do %>
-      <li>
-        <.link {add_phx_attrs(@attrs, @event, @target, @page)}><%= @page %></.link>
-      </li>
+      <.link {add_phx_attrs(@attrs, @event, @target, @page)}><%= @page %></.link>
     <% else %>
-      <li>
-        <.link patch={@page_link_helper.(@page)} {@attrs}>
-          <%= @page %>
-        </.link>
-      </li>
+      <.link patch={@page_link_helper.(@page)} {@attrs}>
+        <%= @page %>
+      </.link>
     <% end %>
     """
   end
@@ -317,7 +311,7 @@ defmodule Flop.Phoenix.Pagination do
 
   defp pagination_ellipsis(assigns) do
     ~H"""
-    <li><span {@attrs}><%= @content %></span></li>
+    <span {@attrs}><%= @content %></span>
     """
   end
 

--- a/lib/flop_phoenix/pagination.ex
+++ b/lib/flop_phoenix/pagination.ex
@@ -121,16 +121,16 @@ defmodule Flop.Phoenix.Pagination do
         opts={@opts}
         target={@target}
       />
-      <.next_link
-        attrs={@opts[:next_link_attrs]}
-        content={@opts[:next_link_content]}
+      <.page_links
         event={@event}
         meta={@meta}
         page_link_helper={@page_link_helper}
         opts={@opts}
         target={@target}
       />
-      <.page_links
+      <.next_link
+        attrs={@opts[:next_link_attrs]}
+        content={@opts[:next_link_content]}
         event={@event}
         meta={@meta}
         page_link_helper={@page_link_helper}

--- a/test/flop_phoenix_test.exs
+++ b/test/flop_phoenix_test.exs
@@ -567,8 +567,6 @@ defmodule Flop.PhoenixTest do
     test "renders page links" do
       html = render_pagination(meta: build(:meta_on_second_page))
 
-      assert [_] = Floki.find(html, "ul[class='pagination-links']")
-
       assert [link] = Floki.find(html, "a[aria-label='Go to page 1']")
       assert Floki.attribute(link, "class") == ["pagination-link"]
       assert Floki.attribute(link, "data-phx-link") == ["patch"]
@@ -637,17 +635,6 @@ defmodule Flop.PhoenixTest do
         )
 
       assert Floki.find(html, ".pagination-links") == []
-    end
-
-    test "allows to overwrite pagination list attributes" do
-      html =
-        render_pagination(
-          meta: build(:meta_on_first_page),
-          opts: [pagination_list_attrs: [class: "p-list", title: "boop"]]
-        )
-
-      assert [list] = Floki.find(html, "ul.p-list")
-      assert Floki.attribute(list, "title") == ["boop"]
     end
 
     test "allows to overwrite pagination link attributes" do


### PR DESCRIPTION
- Re-orders the next button
- Removes ul/li elements so that daisy pagination works properly